### PR TITLE
Improve AI analyzer external request stability

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,10 @@ from starlette.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.api.routes import router as api_router
-from app.api.ai_analyzer import router as ai_analyzer_router
+from app.api.ai_analyzer import (
+    router as ai_analyzer_router,
+    close_ai_analyzer_http_client,
+)
 
 # DB helpers
 from app.db.bitrix import (
@@ -121,6 +124,12 @@ async def on_shutdown() -> None:
         except Exception:
             pass
     _bg_tasks.clear()
+
+    # Закрываем HTTP-клиенты внешних сервисов
+    try:
+        await close_ai_analyzer_http_client()
+    except Exception:
+        log.exception("Failed to close ai-analyzer HTTP client")
 
     # Закрываем коннекты к БД
     engines: list[AsyncEngine | None] = [


### PR DESCRIPTION
## Summary
- reuse a shared httpx.AsyncClient with connection pooling for the external AI analyzer calls and close it during shutdown
- add retry/backoff handling, tighter timeouts, and richer logging around the external analyze request
- ensure generated site variants remain unique while preserving order