### PR TITLE
Add pipeline endpoint for full client processing

### DIFF
--- a/app/api/pipeline.py
+++ b/app/api/pipeline.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from app.db.postgres import get_postgres_engine
+from app.schemas.pipeline import (
+    ParseSiteStage,
+    PipelineClient,
+    PipelineParsSite,
+    PipelineRequest,
+    PipelineResponse,
+    ResolvedIdentifiers,
+)
+from app.services.ai_analyzer import analyze_company_by_inn
+
+log = logging.getLogger("api.pipeline")
+
+router = APIRouter(prefix="/v1/pipeline", tags=["pipeline"])
+
+
+@dataclass
+class _ResolutionResult:
+    client: dict[str, Any]
+    pars: dict[str, Any] | None
+    pars_list: list[dict[str, Any]]
+    inn: str | None
+    site: str | None
+
+
+def _normalize_domain(value: str | None) -> str | None:
+    if not value:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    if "//" not in raw:
+        raw = f"http://{raw}"
+    try:
+        parsed = urlparse(raw)
+    except ValueError:
+        return None
+    host = (parsed.hostname or "").strip().lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host or None
+
+
+async def _fetch_client_by_id(conn: AsyncConnection, client_id: int) -> dict[str, Any] | None:
+    q = text(
+        """
+        SELECT id, company_name, inn, domain_1, domain_2,
+               started_at, ended_at, created_at
+        FROM public.clients_requests
+        WHERE id = :client_id
+        LIMIT 1
+        """
+    )
+    res = await conn.execute(q, {"client_id": client_id})
+    row = res.mappings().first()
+    return dict(row) if row else None
+
+
+async def _fetch_clients_by_inn(conn: AsyncConnection, inn: str) -> list[dict[str, Any]]:
+    q = text(
+        """
+        SELECT id, company_name, inn, domain_1, domain_2,
+               started_at, ended_at, created_at
+        FROM public.clients_requests
+        WHERE inn = :inn
+        ORDER BY COALESCE(ended_at, created_at) DESC NULLS LAST, id DESC
+        """
+    )
+    res = await conn.execute(q, {"inn": inn})
+    return [dict(row) for row in res.mappings().all()]
+
+
+async def _fetch_clients_by_site(conn: AsyncConnection, domain: str) -> list[dict[str, Any]]:
+    pattern = f"%{domain}%"
+    q = text(
+        """
+        SELECT id, company_name, inn, domain_1, domain_2,
+               started_at, ended_at, created_at
+        FROM public.clients_requests
+        WHERE COALESCE(domain_1, '') ILIKE :pattern
+           OR COALESCE(domain_2, '') ILIKE :pattern
+        ORDER BY COALESCE(ended_at, created_at) DESC NULLS LAST, id DESC
+        """
+    )
+    res = await conn.execute(q, {"pattern": pattern})
+    rows: list[dict[str, Any]] = []
+    for row in res.mappings():
+        data = dict(row)
+        domains = [_normalize_domain(data.get("domain_1")), _normalize_domain(data.get("domain_2"))]
+        if any(d == domain for d in domains if d):
+            rows.append(data)
+    return rows
+
+
+async def _fetch_pars_by_id(conn: AsyncConnection, pars_id: int) -> dict[str, Any] | None:
+    q = text(
+        """
+        SELECT id, company_id, domain_1, url, created_at
+        FROM public.pars_site
+        WHERE id = :pars_id
+        LIMIT 1
+        """
+    )
+    res = await conn.execute(q, {"pars_id": pars_id})
+    row = res.mappings().first()
+    return dict(row) if row else None
+
+
+async def _fetch_pars_for_client(conn: AsyncConnection, client_id: int) -> list[dict[str, Any]]:
+    q = text(
+        """
+        SELECT id, company_id, domain_1, url, created_at
+        FROM public.pars_site
+        WHERE company_id = :client_id
+        ORDER BY created_at DESC NULLS LAST, id DESC
+        """
+    )
+    res = await conn.execute(q, {"client_id": client_id})
+    return [dict(row) for row in res.mappings().all()]
+
+
+def _pick_pars_by_domain(rows: Iterable[dict[str, Any]], domain: str | None) -> dict[str, Any] | None:
+    if not domain:
+        return None
+    for row in rows:
+        row_domain = _normalize_domain(row.get("domain_1")) or _normalize_domain(row.get("url"))
+        if row_domain == domain:
+            return row
+    return None
+
+
+async def _resolve_identifiers(conn: AsyncConnection, payload: PipelineRequest) -> _ResolutionResult:
+    inn = (payload.inn or "").strip() or None
+    site_domain = _normalize_domain(payload.site) if payload.site else None
+
+    pars_row = None
+    client_row = None
+    client_id = payload.client_id
+
+    if payload.pars_id is not None:
+        pars_row = await _fetch_pars_by_id(conn, payload.pars_id)
+        if not pars_row:
+            raise HTTPException(status_code=404, detail="pars_id не найден в pars_site")
+        client_id = client_id or pars_row.get("company_id")
+
+    if client_id is not None:
+        client_row = await _fetch_client_by_id(conn, client_id)
+        if not client_row:
+            raise HTTPException(status_code=404, detail="client_id не найден в clients_requests")
+        if pars_row and pars_row.get("company_id") != client_row["id"]:
+            raise HTTPException(status_code=400, detail="Указанные client_id и pars_id принадлежат разным компаниям")
+
+    if client_row is None and inn:
+        candidates = await _fetch_clients_by_inn(conn, inn)
+        if not candidates:
+            raise HTTPException(status_code=404, detail="Не найдена запись clients_requests по ИНН")
+        unique_ids = {c["id"] for c in candidates}
+        if len(unique_ids) > 1 and payload.pars_id is None and payload.client_id is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Найдено несколько клиентов по ИНН. Уточните client_id или pars_id.",
+            )
+        client_row = candidates[0]
+        client_id = client_row["id"]
+
+    if client_row is None and site_domain:
+        candidates = await _fetch_clients_by_site(conn, site_domain)
+        if not candidates:
+            raise HTTPException(status_code=404, detail="Не найдена запись clients_requests по сайту")
+        unique_ids = {c["id"] for c in candidates}
+        if len(unique_ids) > 1 and payload.pars_id is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Найдено несколько клиентов по сайту. Уточните client_id или pars_id.",
+            )
+        client_row = candidates[0]
+        client_id = client_row["id"]
+
+    if client_row is None:
+        raise HTTPException(status_code=400, detail="Не удалось определить клиента по входным данным")
+
+    resolved_inn = inn or (client_row.get("inn") or None)
+    if inn and client_row.get("inn") and client_row["inn"] != inn:
+        raise HTTPException(status_code=400, detail="Указанный client_id не принадлежит заданному ИНН")
+
+    pars_list = await _fetch_pars_for_client(conn, client_row["id"])
+
+    if payload.pars_id is not None and pars_row is None:
+        pars_row = next((p for p in pars_list if p["id"] == payload.pars_id), None)
+        if pars_row is None:
+            raise HTTPException(status_code=404, detail="Указанный pars_id не относится к выбранному клиенту")
+
+    if pars_row is None and site_domain:
+        pars_row = _pick_pars_by_domain(pars_list, site_domain)
+
+    if pars_row is None and pars_list:
+        pars_row = pars_list[0]
+
+    resolved_site = site_domain
+    if not resolved_site:
+        resolved_site = (
+            _normalize_domain((pars_row or {}).get("domain_1"))
+            or _normalize_domain((pars_row or {}).get("url"))
+            or _normalize_domain(client_row.get("domain_1"))
+            or _normalize_domain(client_row.get("domain_2"))
+        )
+
+    return _ResolutionResult(
+        client=client_row,
+        pars=pars_row,
+        pars_list=pars_list,
+        inn=resolved_inn,
+        site=resolved_site,
+    )
+
+
+def _build_parse_stage(resolution: _ResolutionResult) -> ParseSiteStage:
+    client = PipelineClient(**resolution.client)
+    pars_sites = [PipelineParsSite(**{k: row.get(k) for k in ("id", "domain_1", "url", "created_at")}) for row in resolution.pars_list]
+    selected_id = resolution.pars.get("id") if resolution.pars else None
+    return ParseSiteStage(
+        client_id=client.id,
+        client=client,
+        pars_sites=pars_sites,
+        selected_pars_id=selected_id,
+    )
+
+
+def _skipped(detail: str) -> dict[str, Any]:
+    return {"status": "skipped", "detail": detail}
+
+
+@router.post("/full", response_model=PipelineResponse, summary="Полный пайплайн анализа клиента")
+async def run_full_pipeline(payload: PipelineRequest) -> PipelineResponse:
+    started = time.perf_counter()
+
+    engine = get_postgres_engine()
+    if engine is None:
+        raise HTTPException(status_code=503, detail="POSTGRES_DATABASE_URL не задан — пайплайн недоступен")
+
+    async with engine.connect() as conn:
+        resolution = await _resolve_identifiers(conn, payload)
+
+    parse_stage = _build_parse_stage(resolution)
+
+    analyze_result: dict[str, Any] | None = None
+    if payload.run_analyze:
+        if resolution.inn:
+            try:
+                analyze_payload = await analyze_company_by_inn(resolution.inn)
+                analyze_result = {"status": "ok", "payload": analyze_payload}
+            except Exception as exc:  # noqa: BLE001
+                log.exception("Pipeline analyze step failed for inn=%s", resolution.inn)
+                analyze_result = {"status": "error", "detail": str(exc)}
+        else:
+            analyze_result = _skipped("Не удалось определить ИНН для шага анализа")
+
+    response = PipelineResponse(
+        resolved=ResolvedIdentifiers(
+            inn=resolution.inn,
+            site=resolution.site,
+            pars_id=resolution.pars.get("id") if resolution.pars else None,
+            client_id=resolution.client["id"],
+        ),
+        parse_site=parse_stage,
+        analyze=analyze_result,
+        ib_match=_skipped("Шаг IB-match не реализован в этой сборке"),
+        equipment_selection=_skipped("Подбор оборудования не реализован в этой сборке"),
+        duration_ms=int((time.perf_counter() - started) * 1000),
+    )
+    return response

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from app.api.ai_analyzer import (
     router as ai_analyzer_router,
     close_ai_analyzer_http_client,
 )
+from app.api.pipeline import router as pipeline_router
 
 # DB helpers
 from app.db.bitrix import (
@@ -54,6 +55,7 @@ if origins:
 # --- Routers ---
 app.include_router(api_router)
 app.include_router(ai_analyzer_router)
+app.include_router(pipeline_router)
 
 # Хэндлы фоновых задач (для корректной остановки)
 _bg_tasks: List[asyncio.Task] = []

--- a/app/schemas/pipeline.py
+++ b/app/schemas/pipeline.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class PipelineRequest(BaseModel):
+    """Входные параметры для полного пайплайна."""
+
+    inn: str | None = Field(
+        None,
+        min_length=4,
+        max_length=20,
+        description="ИНН клиента. Достаточно любого идентификатора, чтобы связать данные.",
+    )
+    site: str | None = Field(
+        None,
+        description="Сайт компании (домен или URL). Нормализуется до домена без www.",
+    )
+    pars_id: int | None = Field(
+        None,
+        description="Идентификатор записи pars_site.",
+    )
+    client_id: int | None = Field(
+        None,
+        description="Идентификатор клиента (clients_requests.id).",
+    )
+    run_analyze: bool = Field(
+        False,
+        description="Запускать ли шаг анализа перед сопоставлениями.",
+    )
+    analyze_options: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Настройки шага анализа (совместимы с /v1/analyze/{pars_id}).",
+    )
+    ib_match_options: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Опции для шага IB-match.",
+    )
+
+    @model_validator(mode="after")
+    def _ensure_identifier_present(self) -> "PipelineRequest":  # noqa: D401
+        """Проверяет, что указан хотя бы один идентификатор."""
+
+        if not any([self.inn, self.site, self.pars_id, self.client_id]):
+            raise ValueError(
+                "Необходимо указать хотя бы один идентификатор: inn, site, pars_id или client_id."
+            )
+        return self
+
+
+class ResolvedIdentifiers(BaseModel):
+    """Итоговые значения идентификаторов после разрешения."""
+
+    inn: str | None = None
+    site: str | None = None
+    pars_id: int | None = None
+    client_id: int
+
+
+class PipelineClient(BaseModel):
+    """Сведения о выбранной записи клиента."""
+
+    id: int
+    company_name: str | None = None
+    inn: str | None = None
+    domain_1: str | None = None
+    domain_2: str | None = None
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+    created_at: datetime | None = None
+
+
+class PipelineParsSite(BaseModel):
+    """Краткие сведения по записи pars_site."""
+
+    id: int
+    domain_1: str | None = None
+    url: str | None = None
+    created_at: datetime | None = None
+
+
+class ParseSiteStage(BaseModel):
+    """Блок с информацией о pars_site и клиенте."""
+
+    client_id: int
+    client: PipelineClient
+    pars_sites: list[PipelineParsSite]
+    selected_pars_id: int | None = None
+
+
+class PipelineResponse(BaseModel):
+    """Полный ответ пайплайна."""
+
+    resolved: ResolvedIdentifiers
+    parse_site: ParseSiteStage
+    analyze: Optional[dict[str, Any]] = None
+    ib_match: Optional[dict[str, Any]] = None
+    equipment_selection: Optional[dict[str, Any]] = None
+    duration_ms: int


### PR DESCRIPTION
## Summary
- add pipeline schemas that describe request, parse-site stage, and overall response payloads
- implement /v1/pipeline/full endpoint that resolves identifiers, assembles parse-site data, and optionally runs analyze lookup
- register the new pipeline router in the FastAPI application